### PR TITLE
Hydrate the Menu's items with their children

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -44,7 +44,7 @@
     <rule ref="rulesets/naming.xml/ShortClassName"/>
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
-            <property name="exceptions" value="id,em"/>
+            <property name="exceptions" value="id,em,qb"/>
         </properties>
     </rule>
     <rule ref="rulesets/naming.xml/ShortMethodName"/>

--- a/src/Entity/MenuItem.php
+++ b/src/Entity/MenuItem.php
@@ -130,6 +130,14 @@ class MenuItem implements MenuItemInterface
     /**
      * {@inheritdoc}
      */
+    public function setItems(?Collection $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasItem(MenuItemInterface $item): bool
     {
         if (null === $this->items) {

--- a/src/Entity/MenuItemInterface.php
+++ b/src/Entity/MenuItemInterface.php
@@ -53,6 +53,11 @@ interface MenuItemInterface extends ResourceInterface, TranslatableInterface
     public function getItems(): ?Collection;
 
     /**
+     * @param Collection|null $items
+     */
+    public function setItems(?Collection $items): void;
+
+    /**
      * @param MenuItemInterface $item
      *
      * @return bool

--- a/src/Hydrator/MenuTreeHydrator.php
+++ b/src/Hydrator/MenuTreeHydrator.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' menu plugin for Sylius.
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusMenuPlugin\Hydrator;
+
+use Doctrine\Common\Collections\Collection;
+use MonsieurBiz\SyliusMenuPlugin\Entity\MenuInterface;
+use MonsieurBiz\SyliusMenuPlugin\Entity\MenuItemInterface;
+
+final class MenuTreeHydrator
+{
+    public function __invoke(?MenuInterface $menu): ?MenuInterface
+    {
+        if (null !== $menu) {
+            foreach ($menu->getFirstLevelItems() as $menuItem) {
+                $this->fillItems($menuItem);
+            }
+        }
+
+        return $menu;
+    }
+
+    private function fillItems(MenuItemInterface $item): void
+    {
+        if (null === $item->getMenu() || null === $item->getMenu()->getItems()) {
+            return;
+        }
+        $items = $this->filterItemsByParent(
+            $item->getMenu()->getItems(),
+            $item
+        );
+        $item->setItems($items);
+    }
+
+    private function filterItemsByParent(Collection $items, MenuItemInterface $parentItem): Collection
+    {
+        return $items->filter(function(MenuItemInterface $subItem) use ($parentItem): bool {
+            if (null === $subItem->getParent()) {
+                return false;
+            }
+            if ($subItem->getParent()->getId() === $parentItem->getId()) {
+                $this->fillItems($subItem);
+
+                return true;
+            }
+
+            return false;
+        });
+    }
+}

--- a/src/Repository/MenuRepository.php
+++ b/src/Repository/MenuRepository.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MonsieurBiz\SyliusMenuPlugin\Repository;
 
 use MonsieurBiz\SyliusMenuPlugin\Entity\MenuInterface;
+use MonsieurBiz\SyliusMenuPlugin\Hydrator\MenuTreeHydrator;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 class MenuRepository extends EntityRepository implements MenuRepositoryInterface
@@ -29,6 +30,6 @@ class MenuRepository extends EntityRepository implements MenuRepositoryInterface
             ->setParameter('code', $code)
         ;
 
-        return $qb->getQuery()->getOneOrNullResult();
+        return (new MenuTreeHydrator())($qb->getQuery()->getOneOrNullResult());
     }
 }


### PR DESCRIPTION
It allows us to avoid "a few" SQL requests, depending on how many items with children you have.
