### PR TITLE
allow cascade remove on menu

### DIFF
--- a/src/Resources/config/doctrine/Menu.orm.xml
+++ b/src/Resources/config/doctrine/Menu.orm.xml
@@ -17,6 +17,7 @@
         <one-to-many field="items" target-entity="MonsieurBiz\SyliusMenuPlugin\Entity\MenuItemInterface" mapped-by="menu" fetch="EAGER">
             <cascade>
                 <cascade-persist/>
+                <cascade-remove/>
             </cascade>
             <order-by>
                 <order-by-field name="position" direction="ASC"/>


### PR DESCRIPTION
Menu delete throw an error if there are MenuItems in the Menu
Adding `<cascade-remove/>` in Menu.orm.xml fix the problem