### PR TITLE
CI: determine the cache folder of composer to cache it correctly

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -55,14 +55,21 @@ jobs:
           docker run --rm --name flex -d -v $PWD/plugin/recipes:/var/www/flex/var/repo/private/monsieurbiz/sylius-menu-plugin -p 80:80 docker.pkg.github.com/monsieurbiz/docker/symfony-flex-server:latest contrib official
           docker ps
 
-      - run: mkdir -p /home/runner/{.composer/cache,.config/composer}
+      - name: Determine composer cache directory
+        id: composer-cache-directory
+        working-directory: plugin
+        run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v1
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v2
         id: cache-composer
         with:
-          path: /home/runner/.composer/cache
+          path: ${{ steps.composer-cache-directory.outputs.directory }}
           key: composer2-php:${{ matrix.php }}-sylius:${{ matrix.sylius }}-${{ github.sha }}
           restore-keys: composer2-php:${{ matrix.php }}-sylius:${{ matrix.sylius }}-
+
+      - name: Ensure that composer cache directory exists
+        run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
       - name: Composer v2
         run: sudo composer self-update --2

--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -71,9 +71,6 @@ jobs:
       - name: Ensure that composer cache directory exists
         run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
-      - name: Composer v2
-        run: sudo composer self-update --2
-
       - name: Composer Github Auth
         run: composer config -g github-oauth.github.com ${{ github.token }}
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -28,15 +28,20 @@ jobs:
         run: |
           echo "${{ matrix.php }}" > .php-version
 
-      - uses: actions/cache@v1
+      - name: Determine composer cache directory
+        id: composer-cache-directory
+        run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v2
         id: cache-composer
         with:
-          path: /home/runner/.composer/cache
+          path: ${{ steps.composer-cache-directory.outputs.directory }}
           key: composer2-php:${{ matrix.php }}-${{ github.sha }}
           restore-keys: composer2-php:${{ matrix.php }}-
 
-      - run: mkdir -p /home/runner/{.composer/cache,.config/composer}
-        if: steps.cache-composer.outputs.cache-hit != 'true'
+      - name: Ensure that composer cache directory exists
+        run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
       - name: Composer v2
         run: sudo composer self-update --2

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -43,9 +43,6 @@ jobs:
       - name: Ensure that composer cache directory exists
         run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
-      - name: Composer v2
-        run: sudo composer self-update --2
-
       - name: Composer Github Auth
         run: composer config -g github-oauth.github.com ${{ github.token }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,9 +56,6 @@ jobs:
       - name: Ensure that composer cache directory exists
         run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
-      - name: Composer v2
-        run: sudo composer self-update --2
-
       - name: Composer Github Auth
         run: composer config -g github-oauth.github.com ${{ github.token }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,15 +41,20 @@ jobs:
           curl https://get.symfony.com/cli/installer | bash
           echo "${HOME}/.symfony5/bin" >> $GITHUB_PATH
 
-      - uses: actions/cache@v1
+      - name: Determine composer cache directory
+        id: composer-cache-directory
+        run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v2
         id: cache-composer
         with:
-          path: /home/runner/.composer/cache
+          path: ${{ steps.composer-cache-directory.outputs.directory }}
           key: composer2-php:${{ matrix.php }}-${{ github.sha }}
           restore-keys: composer2-php:${{ matrix.php }}-
 
-      - run: mkdir -p /home/runner/{.composer/cache,.config/composer}
-        if: steps.cache-composer.outputs.cache-hit != 'true'
+      - name: Ensure that composer cache directory exists
+        run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
       - name: Composer v2
         run: sudo composer self-update --2


### PR DESCRIPTION
## Fix permission

Because of an action launched in `sudo`, we had the wrong rights on the compose config files:

![image](https://github.com/monsieurbiz/SyliusMenuPlugin/assets/465524/e0220ad1-92df-4626-a718-32ca1e985536)

In addition, we're already in version 2 of composer, so this action wasn't necessary. It has been removed from this PR.

## Cache optimization

**Before**

See [9488970164](https://github.com/monsieurbiz/SyliusMenuPlugin/actions/runs/5252653562/jobs/9488970164):

![image](https://github.com/monsieurbiz/SyliusMenuPlugin/assets/465524/6a4feb7e-adbc-44fa-97d6-653fb5ed5dd7)

![image](https://github.com/monsieurbiz/SyliusMenuPlugin/assets/465524/53658ca6-91b3-44a0-b60d-d42de30f154d)


**After**

See [9501145026](https://github.com/monsieurbiz/SyliusMenuPlugin/actions/runs/5257807262/jobs/9501145026):

![image](https://github.com/monsieurbiz/SyliusMenuPlugin/assets/465524/627bcddf-f048-4394-97ce-0a33798400ff)

![image](https://github.com/monsieurbiz/SyliusMenuPlugin/assets/465524/3d7ff6d5-81e9-4718-8ed2-b14f8a7ab8c3)
