### PR TITLE
Add permission on routes 

### DIFF
--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -2,6 +2,7 @@ monsieurbiz_menu_admin_menu:
     resource: |
         alias: monsieurbiz_menu.menu
         section: admin
+        permission: true
         templates: "@MonsieurBizSyliusMenuPlugin/Admin/Menu"
         except: ['show', 'bulkDelete']
         redirect: index

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -21,3 +21,11 @@ monsieurbiz_menu:
         help_noopener: 'Add "noopener" to the rel attribute'
         nofollow: 'nofollow'
         help_nofollow: 'Add "nofollow" to the rel attribute'
+sylius_plus:
+    rbac:
+        parent:
+            menus: 'Menus'
+        action:
+            create_for_menu: 'Create for menu'
+            move_up: 'Move up'
+            move_down: 'Move down'

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -21,3 +21,11 @@ monsieurbiz_menu:
         help_noopener: 'Ajoute "noopener" à l''attribut rel'
         nofollow: 'nofollow'
         help_nofollow: 'Ajoute "nofollow" à l''attribut rel'
+sylius_plus:
+    rbac:
+        parent: 
+            menus: 'Menus'
+        action:
+            create_for_menu: 'Créer pour le menu'
+            move_up: 'Déplacer vers le haut'
+            move_down: 'Déplacer vers le bas'


### PR DESCRIPTION
Add permission on routes so the RBAC of Sylius Plus can put be used for the routes of the plugin.

For Sylius Standard it's changing nothing.