### PR TITLE
Fix: avoid server error with a product without slug for wanted locale

### DIFF
--- a/src/Provider/ProductUrlProvider.php
+++ b/src/Provider/ProductUrlProvider.php
@@ -38,6 +38,7 @@ class ProductUrlProvider extends AbstractUrlProvider
     protected function getResults(string $locale, string $search = ''): iterable
     {
         $queryBuilder = $this->productRepository->createListQueryBuilder($locale)
+            ->andWhere('translation.locale = :locale') // Add condition to display only pages with the current locale
             ->andWhere('o.enabled = :enabled')
             ->setParameter('enabled', true)
         ;


### PR DESCRIPTION
cf https://github.com/monsieurbiz/SyliusCmsPagePlugin/pull/81 for the explication

FYI, the TaxonUrlProvider already has the translation condition