### PR TITLE
TASK: add hint in readme about default sylius menu codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ To get the first items of a menu, you can call the `getMenuItems` method of the 
 Replace `menu_code` with the code of the menu you want to display.  
 Then you can loop through the items and display them as you want.
 
+**Note:**
+For the default Sylius menus the following menu codes are available: `menu`, `customer_care`, or `your_store`. If you want to use one of those menus, make sure you create a menu with one of those codes.
+
 **Advanced example**
 
 If you wish to define a menu code by channel and/or locale, we recommend you use the [plugin Settings](https://github.com/monsieurbiz/SyliusSettingsPlugin).


### PR DESCRIPTION
**Description**

We found out that the menu only gets visible when i create a menu with the name `main` for example. Then i saw in: https://github.com/monsieurbiz/SyliusMenuPlugin/blob/2.x/src/Resources/config/services.yaml that the custom sylius menu names are hardcoded: `main` `your_store`, `customer_care`. And there was no info about that in the README.